### PR TITLE
Don't use hmr if `_hmr` is undefined (e.g. in a web worker)

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,8 +272,8 @@ module.exports = function(bundle, opts) {
         } else {
           isNew = true;
           thunk = function() {
-            var header = '_hmr['+JSON.stringify(bundleKey)+
-              '].initModule('+JSON.stringify(fileKey(row.file))+', module);\n(function(){\n';
+            var header = 'if (typeof _hmr !== "undefined") {_hmr['+JSON.stringify(bundleKey)+
+              '].initModule('+JSON.stringify(fileKey(row.file))+', module);}\n(function(){\n';
             var footer = '\n}).apply(this, arguments);\n';
 
             var inputMapCV = convert.fromSource(row.source);


### PR DESCRIPTION
When using [`webworkify`](https://github.com/substack/webworkify) `browserify-hmr` throws an error `_hmr is undefined` because this global is not defined in the webworker context. This is a quick fix that simply does not try to hot-reload web worker scripts if `_hmr` is not defined. This works for me since I'm not actively editing web worker scripts, the hot reloading is more useful for UI work.
